### PR TITLE
Added :has() support for empty kotoba boxes

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -262,6 +262,15 @@ p {
     text-shadow: none;
 }
 
+table:has(.none-available) + .see-more a.small-caps {
+  display: none;
+}
+
+table:has(.none-available) + div.see-more {
+  padding: 7.5px 30px;
+  background-color: var(--ED-surface-3) !important;
+}
+
 .sitemap__expandable-chunk,
 .extra-study > div,
 .review-forecast__day,


### PR DESCRIPTION
If the browser supports the `:has()` pseudo class, the "see more" button should not longer appear in empty boxes.

![obrazek](https://user-images.githubusercontent.com/82216846/213803442-15b56212-6ac0-4301-a0e4-21bace0f1aff.png)

If it doesn't, the new new style is going to be ignored and should not cause any troubles.

![obrazek](https://user-images.githubusercontent.com/82216846/213803781-11936e32-0de2-47ad-85fc-6cff2d9b6b3a.png)

Both pictures taken from firefox. 1st with `layout.css.has-selector.enabled` enabled, 2nd with `layout.css.has-selector.enabled` disabled