### PR TITLE
36 visual changes

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -74,12 +74,12 @@
   --ED-extra-clr: var(--ED-yellow);
 
   /* Indicate SRS stages */
-  --ED-apprentice-clr: var(--ED-blue);
-  --ED-guru-clr: var(--ED-red);
-  --ED-master-clr: var(--ED-green);
-  --ED-enlightened-clr: var(--ED-yellow);
-  --ED-burned-clr: var(--ED-gray-6);
-
+  --ED-apprentice-clr: var(--ED-gray-6);
+  --ED-guru-clr: var(--ED-gray-yellow);
+  --ED-master-clr: var(--ED-yellow);
+  --ED-enlightened-clr: var(--ED-yellow-red);
+  --ED-burned-clr: var(--ED-red);
+  
   /* Indicate review vs. lesson */
   --ED-lesson-clr: var(--ED-radical-clr);
   --ED-review-clr: var(--ED-kanji-clr);
@@ -156,6 +156,9 @@
   --ED-yellow-hsl: 35, 44%, 46%; /* makes light text work */
   --ED-yellow-light-hsl: 35, 44%, 66%;
   --ED-yellow-dark-hsl: 35, 39%, 26%;
+  
+  --ED-gray-yellow-hsl: 35, 27%, 36%;
+  --ED-yellow-red-hsl: 19, 41%, 45%;
 
   /*
    * Colors defined from the HSL values above
@@ -174,6 +177,8 @@
   --ED-yellow-light: hsl(var(--ED-yellow-light-hsl));
   --ED-yellow-dark: hsl(var(--ED-yellow-dark-hsl));
   
+  --ED-gray-yellow: hsl(var(--ED-gray-yellow-hsl));
+  --ED-yellow-red: hsl(var(--ED-yellow-red-hsl));
   /*
   * If, for example, you needed a 50% transparent overlay of a dark
   * green color, you could use: 

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -887,6 +887,11 @@ border-color: transparent transparent transparent var(--ED-light-surface-5);
   background-color: var(--ED-surface-2);
 }
 
+#reviews #progress-bar,
+#lesson #progress-bar {
+  height: 10px;
+}
+
 #progress-bar #bar {
   background-color: var(--ED-progress-clr);
 }

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -702,19 +702,24 @@ section.srs-progress ul li:last-child {
 }
 
 /* RRW answered incorrectly headers */
-#reviews-summary #incorrect h2,
-#lessons-summary #radicals h2 {
+#reviews-summary #incorrect h2 {
   background-color: var(--ED-incorrect);
 }
 
-/* RRW missing radicals and vocabulary? Revisit this */
+#lessons-summary #radicals h2 {
+  background-color: var(--ED-radical-clr);
+}
+
 #lessons-summary #kanji h2 {
   background-color: var(--ED-kanji-clr);
 }
 
-/* RRW answered correctly headers */
-#reviews-summary #correct h2,
 #lessons-summary #vocabulary h2 {
+  background-color: var(--ED-vocab-clr);
+}
+
+/* RRW answered correctly headers */
+#reviews-summary #correct h2 {
   background-color: var(--ED-correct);
 }
 

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -74,7 +74,7 @@
   --ED-extra-clr: var(--ED-yellow);
 
   /* Indicate SRS stages */
-  --ED-apprentice-clr: var(--ED-gray-6);
+  --ED-apprentice-clr: var(--ED-gray-7);
   --ED-guru-clr: var(--ED-gray-yellow);
   --ED-master-clr: var(--ED-yellow);
   --ED-enlightened-clr: var(--ED-yellow-red);
@@ -157,7 +157,7 @@
   --ED-yellow-light-hsl: 35, 44%, 66%;
   --ED-yellow-dark-hsl: 35, 39%, 26%;
   
-  --ED-gray-yellow-hsl: 35, 27%, 36%;
+  --ED-gray-yellow-hsl: 35, 25%, 39%;
   --ED-yellow-red-hsl: 19, 41%, 45%;
 
   /*

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -68,21 +68,21 @@
   --ED-reading-clr: var(--ED-gray-3);
 
   /* Indicate item types */
-  --ED-radical-clr: var(--ED-red);
-  --ED-kanji-clr: var(--ED-blue);
+  --ED-radical-clr: var(--ED-blue);
+  --ED-kanji-clr: var(--ED-red);
   --ED-vocab-clr: var(--ED-green);
   --ED-extra-clr: var(--ED-yellow);
 
   /* Indicate SRS stages */
-  --ED-apprentice-clr: var(--ED-yellow-desat1);
-  --ED-guru-clr: var(--ED-yellow-desat2);
-  --ED-master-clr: var(--ED-yellow-desat3);
-  --ED-enlightened-clr: var(--ED-yellow-desat4);
-  --ED-burned-clr: var(--ED-yellow-desat5);
+  --ED-apprentice-clr: var(--ED-blue);
+  --ED-guru-clr: var(--ED-red);
+  --ED-master-clr: var(--ED-green);
+  --ED-enlightened-clr: var(--ED-yellow);
+  --ED-burned-clr: var(--ED-gray-6);
 
   /* Indicate review vs. lesson */
-  --ED-lesson-clr: var(--ED-yellow-desat1);
-  --ED-review-clr: var(--ED-red);
+  --ED-lesson-clr: var(--ED-radical-clr);
+  --ED-review-clr: var(--ED-kanji-clr);
 
   /* Alerts/warnings */
   --ED-alert-clr: var(--ED-red);
@@ -90,7 +90,7 @@
   --ED-success-clr: var(--ED-green);
 
   /* Progress bars */
-  --ED-progress-clr: var(--ED-brand);
+  --ED-progress-clr: var(--ED-yellow);
 
   /* TODO: Box shadows, gradients */
 
@@ -141,45 +141,39 @@
 
   --ED-red-hsl: 1, 39%, 44%; /* Bunpro #9d4745 */
   --ED-red-light-hsl: 1, 39%, 64%;
-  --ED-red-dark-hsl: 1, 39%, 24%;
-
+  --ED-red-dark-hsl: 1, 34%, 24%;
+  
   --ED-blue-hsl: 225, 23%, 44%; /* Bunpro #56638a */
   --ED-blue-light-hsl: 225, 23%, 64%;
-  --ED-blue-dark-hsl: 225, 23%, 24%;
+  --ED-blue-dark-hsl: 225, 18%, 24%;
 
   /* --ED-green-hsl: 166, 36%, 52%; /* Bunpro #58b09c */
-  --ED-green-hsl: 166, 36%, 32%; /* makes light text work */
-  --ED-green-light-hsl: 166, 36%, 72%;
-  --ED-green-dark-hsl: 166, 36%, 22%;
+  --ED-green-hsl: 148, 22%, 44%; /* makes light text work */
+  --ED-green-light-hsl: 148, 22%, 64%;
+  --ED-green-dark-hsl: 148, 17%, 24%;
 
   /* --ED-yellow-hsl: 37, 56%, 64%; /* Bunpro #d7af70 */
-  --ED-yellow-hsl: 36, 56%, 44%; /* makes light text work */
-  --ED-yellow-light-hsl: 37, 56%, 84%;
-  --ED-yellow-dark-hsl: 37, 56%, 34%;
-  --ED-yellow-desat1-hsl: 37, 16%, 24%;
-  --ED-yellow-desat2-hsl: 37, 26%, 34%;
-  --ED-yellow-desat3-hsl: 37, 36%, 34%;
-  --ED-yellow-desat4-hsl: 37, 46%, 44%;
-  --ED-yellow-desat5-hsl: 37, 56%, 44%;
+  --ED-yellow-hsl: 35, 44%, 46%; /* makes light text work */
+  --ED-yellow-light-hsl: 35, 44%, 66%;
+  --ED-yellow-dark-hsl: 35, 39%, 26%;
 
   /*
    * Colors defined from the HSL values above
    */
   --ED-red: hsl(var(--ED-red-hsl));
   --ED-red-light: hsl(var(--ED-red-light-hsl));
+  --ED-red-dark: hsl(var(--ED-red-dark-hsl));
 
   --ED-blue: hsl(var(--ED-blue-hsl));
+  --ED-blue-dark: hsl(var(--ED-blue-dark-hsl));
 
   --ED-green: hsl(var(--ED-green-hsl));
+  --ED-green-dark: hsl(var(--ED-green-dark-hsl));
 
   --ED-yellow: hsl(var(--ED-yellow-hsl));
   --ED-yellow-light: hsl(var(--ED-yellow-light-hsl));
-  --ED-yellow-desat1: hsl(var(--ED-yellow-desat1-hsl));
-  --ED-yellow-desat2: hsl(var(--ED-yellow-desat2-hsl));
-  --ED-yellow-desat3: hsl(var(--ED-yellow-desat3-hsl));
-  --ED-yellow-desat4: hsl(var(--ED-yellow-desat4-hsl));
-  --ED-yellow-desat5: hsl(var(--ED-yellow-desat5-hsl));
-
+  --ED-yellow-dark: hsl(var(--ED-yellow-dark-hsl));
+  
   /*
   * If, for example, you needed a 50% transparent overlay of a dark
   * green color, you could use: 
@@ -448,7 +442,7 @@ footer ul li:last-child {
 
 /* RRW Can't find this, either (not a newbie tho :-) */
 .dashboard section.newbie hr {
-  border-color: chartreuse;
+  border-color: var(--ED-brand);
 }
 
 section.srs-progress ul li:first-child,
@@ -468,14 +462,10 @@ section.srs-progress span {
   color: var(--ED-text-color);
 }
 
-/* RRW Note: I think it's okay to use palette colors directly here instead of semantic names */
 .radical-icon--locked,
 .kanji-icon--locked {
-  background-image: linear-gradient(
-    180deg,
-    var(--ED-gray-11) 0%,
-    var(--ED-gray-10) 100%
-  ) !important;
+  background-color: var(--ED-surface-4) !important;
+  filter: brightness(80%);
 }
 
 .kotoba-table-list table a span,
@@ -616,6 +606,10 @@ section.srs-progress ul li:nth-child(3) {
 
 section.srs-progress ul li:nth-child(4) {
   background-color: var(--ED-enlightened-clr);
+}
+
+section.srs-progress ul li:last-child {
+  background-color: var(--ED-burned-clr);
 }
 
 /* Guru progress indicators under indiviual items */

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -289,7 +289,7 @@ table:has(.none-available) + div.see-more {
 .extra-study img,
 .review-forecast__empty-image,
 .none-available div {
-  filter: invert(0.86);
+  filter: invert(0.81);
 }
 
 .review-forecast__day-header::before {

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -892,7 +892,8 @@ border-color: transparent transparent transparent var(--ED-light-surface-5);
 }
 
 #reviews #progress-bar,
-#lesson #progress-bar {
+#lessons #progress-bar,
+#lessons #progress-bar #bar{
   height: 10px;
 }
 

--- a/color-spins/WKED-WaniKani-Default-Colors.txt
+++ b/color-spins/WKED-WaniKani-Default-Colors.txt
@@ -1,0 +1,1735 @@
+:root {
+  /* CSS variables (technically, "custom properties") for theming */
+
+  /*
+   * Semantic variables
+   *
+   * Edit these to specify your desired colors.
+   *
+   * You can use the palette colors defined below (as shown) or use CSS
+   * color definitions (e.g. "-ED-surface-1: #223344;"). 
+   *
+   * Note that this stylesheet assume a dark theme! It specifically uses
+   * light text (colored with --ED-text-light) over everything except
+   * containers with a background color of --ED-light-surface-5.
+   *
+   * For the most part, the palette colors below shouldn't be used in CSS
+   * rules directly. Instead, use these semantically named variables.
+   *
+   * Users can then modify these as they like, and all pages will update
+   * accordingly (without weird surprises).
+   */
+
+  /* 
+   * Surfaces / overlapping containers for layout
+   */
+  --ED-surface-1: var(--ED-gray-1); /* darkest, farthest back */
+  --ED-surface-2: var(--ED-gray-3);
+  --ED-surface-3: var(--ED-gray-5);
+  --ED-surface-4: var(--ED-gray-7); /* lightest, closest to user */
+
+  /* 
+   * Light surfaces. Text will be colored with --ED-text-dark
+   */
+  --ED-light-surface-5: var(--ED-gray-9);
+
+  /*
+   * Text colors 
+   */
+
+  /* 
+   * One color for dark backgrounds, one for light.
+   *
+   * --ED-text-dark is used over --ED-light-surface-5 ONLY
+   *
+   * --ED-text-light is used everywhere else
+   */
+  --ED-text-light: var(--ED-gray-12); /* light text -- used EVERYWHERE */
+  --ED-text-dark: var(--ED-gray-1); /* dark text used over light surface o*/
+
+  /* Specially coloring needs */
+  --ED-highlight-text: var(--ED-yellow); /* emphasized */
+  --ED-grayed-text: var(--ED-gray-8); /* de-emphasized */
+
+  /*
+   * Other semantic types
+   */
+
+  /* Theme/branding colors */
+  --ED-brand: var(--WK-enlightened);
+  --ED-brand-alt: var(--ED-yellow);
+
+  /* Indicate correct/incorrect answers */
+  --ED-correct: var(--ED-green);
+  --ED-incorrect: var(--ED-red);
+
+  /* Indicate reading vs. meaning */
+  --ED-meaning-clr: var(--ED-yellow);
+  --ED-reading-clr: var(--ED-gray-3);
+
+  /* Indicate item types */
+  --ED-radical-clr: var(--WK-enlightened);
+  --ED-kanji-clr: var(--WK-apprentice);
+  --ED-vocab-clr: var(--WK-guru);
+  --ED-extra-clr: var(--ED-yellow);
+
+  /* Indicate SRS stages */
+  --ED-apprentice-clr: var(--WK-apprentice);
+  --ED-guru-clr: var(--WK-guru);
+  --ED-master-clr: var(--WK-master);
+  --ED-enlightened-clr: var(--WK-enlightened);
+  --ED-burned-clr: var(--ED-gray-6);
+
+  /* Indicate review vs. lesson */
+  --ED-lesson-clr: var(--ED-radical-clr);
+  --ED-review-clr: var(--ED-kanji-clr);
+
+  /* Alerts/warnings */
+  --ED-alert-clr: var(--ED-red);
+  --ED-warn-clr: var(--ED-yellow);
+  --ED-success-clr: var(--ED-green);
+
+  /* Progress bars */
+  --ED-progress-clr: var(--ED-yellow);
+
+  /* TODO: Box shadows, gradients */
+
+  /*
+   * Color palette
+   *
+   * Define any colors you need for the the variables above. They won't be 
+   * directly used by any of the CSS rules below.
+   *
+   * This stylesheet doesn't use palette colors directly, instead, it uses
+   * the variables defined above that have "semantic" names (names that
+   * describe what something is, does, or means, rather than merely what it 
+   * looks like).
+   *
+   * In general, themes that limit the total number of hues look best. 
+   *
+   * It's okay if some, or even many, of the colors defined here aren't used.
+   *
+   */
+
+  /* 
+   *  Grays 
+   */
+
+  --ED-gray-1: #151515; /* darkest */
+  --ED-gray-2: #242424;
+  --ED-gray-3: #282828;
+  --ED-gray-4: #2c2c2c;
+  --ED-gray-5: #303030;
+  --ED-gray-6: #434343;
+  --ED-gray-7: #535353;
+  --ED-gray-8: #aaaaaa;
+  --ED-gray-9: #bababa;
+  --ED-gray-10: #bfbfbf;
+  --ED-gray-11: #cccccc;
+  --ED-gray-12: #eeeeee;
+
+  --ED-pure-black: #000;
+  --ED-pure-white: #fff;
+
+  /*
+   * HSL values
+   *
+   * Colors defined using hue/saturation/lightness values make 
+   * it easy to create tints and shades as shown below. It also makes 
+   * it easy to use transparency with hsla().
+   */
+
+  --ED-red-hsl: 1, 39%, 44%; /* Bunpro #9d4745 */
+  --ED-red-light-hsl: 1, 39%, 64%;
+  --ED-red-dark-hsl: 1, 34%, 24%;
+  
+  --ED-blue-hsl: 225, 23%, 44%; /* Bunpro #56638a */
+  --ED-blue-light-hsl: 225, 23%, 64%;
+  --ED-blue-dark-hsl: 225, 18%, 24%;
+
+  /* --ED-green-hsl: 166, 36%, 52%; /* Bunpro #58b09c */
+  --ED-green-hsl: 148, 22%, 44%; /* makes light text work */
+  --ED-green-light-hsl: 148, 22%, 64%;
+  --ED-green-dark-hsl: 148, 17%, 24%;
+
+  /* --ED-yellow-hsl: 37, 56%, 64%; /* Bunpro #d7af70 */
+  --ED-yellow-hsl: 35, 44%, 46%; /* makes light text work */
+  --ED-yellow-light-hsl: 35, 44%, 66%;
+  --ED-yellow-dark-hsl: 35, 39%, 26%;
+
+  --WK-apprentice-hsl: 320, 50%, 43%;
+  --WK-guru-hsl: 288, 50%, 40%;
+  --WK-master-hsl: 228, 50%, 51%;
+  --WK-enlightened-hsl: 200, 50%, 43%;
+  --WK-burned-hsl: 0, 0%, 26%;
+  
+  /*
+   * Colors defined from the HSL values above
+   */
+  --ED-red: hsl(var(--ED-red-hsl));
+  --ED-red-light: hsl(var(--ED-red-light-hsl));
+  --ED-red-dark: hsl(var(--ED-red-dark-hsl));
+
+  --ED-blue: hsl(var(--ED-blue-hsl));
+  --ED-blue-dark: hsl(var(--ED-blue-dark-hsl));
+
+  --ED-green: hsl(var(--ED-green-hsl));
+  --ED-green-dark: hsl(var(--ED-green-dark-hsl));
+
+  --ED-yellow: hsl(var(--ED-yellow-hsl));
+  --ED-yellow-light: hsl(var(--ED-yellow-light-hsl));
+  --ED-yellow-dark: hsl(var(--ED-yellow-dark-hsl));
+  
+  --WK-apprentice: hsl(var(--WK-apprentice-hsl));
+  --WK-guru: hsl(var(--WK-guru-hsl));
+  --WK-master: hsl(var(--WK-master-hsl));
+  --WK-enlightened: hsl(var(--WK-enlightened-hsl));
+  --WK-burned: hsl(var(--WK-apprentice-hsl));
+  
+  /*
+  * If, for example, you needed a 50% transparent overlay of a dark
+  * green color, you could use: 
+  *
+  *         --ED-my-color: hsla(var(--ED-yellow-dark-hsl), 0.5);
+  */
+}
+
+/*************************************************************************************************
+ * 
+ * BEGIN CSS RULES
+ *
+ *                 ** NOTHING BELOW THIS POINT IS INTENDED TO BE EDITED **
+ *
+/*************************************************************************************************/
+
+/* General reset */
+
+body,
+.dashboard section.dashboard-sub-section div.see-more {
+  background-color: var(--ED-surface-1);
+  background-image: none;
+
+  /* Default color assumes dark background */
+  --ED-text-color: var(--ED-text-light); /* default */
+}
+
+.global-header,
+.sitemap {
+  background-color: var(--ED-surface-2);
+  background-image: none;
+  border-color: var(--ED-surface-4);
+}
+
+.navigation__toggle-lines,
+.navigation__toggle-lines::before,
+.navigation__toggle-lines::after {
+  border-color: var(--ED-text-color);
+}
+
+span,
+a,
+h1,
+h3,
+.extra-study > div p,
+time,
+.text-right,
+.text-left,
+.font-sans,
+.navigation-shortcut a,
+.text-sm,
+.recent-unlocks > h3,
+.see-more > a,
+.dashboard-sub-section h3,
+.dashboard section.dashboard-sub-section a.small-caps,
+.forum-topics-list a.topic-title,
+.forum-topics-list a,
+.small-caps.invert,
+.kotoba-table-list table tr.none-available,
+p {
+  color: var(--ED-text-color);
+  text-shadow: none;
+}
+
+.dashboard .forum-topics-list h3.small-caps.invert div.heading-symbol {
+  border-color: var(--ED-text-color);
+}
+
+/*************************************************************************************************
+* Dashboard page specifics
+/*************************************************************************************************/
+
+.review-forecast__toggleicon {
+  color: var(--ED-brand);
+}
+
+.kotoba-table-list table tr.none-available {
+    background-color: var(--ED-surface-3);
+    color: var(--ED-text-color);
+    text-shadow: none;
+}
+
+table:has(.none-available) + .see-more a.small-caps {
+  display: none;
+}
+
+table:has(.none-available) + div.see-more {
+  padding: 7.5px 30px;
+  background-color: var(--ED-surface-3) !important;
+}
+
+.sitemap__expandable-chunk,
+.extra-study > div,
+.review-forecast__day,
+.bg-white {
+  background-color: var(--ED-surface-3);
+}
+
+.sitemap__grouped-pages > .sitemap__page > a,
+.navigation__toggle[data-expanded="true"] {
+  background-color: var(--ED-surface-3);
+}
+
+.extra-study,
+.dashboard section.forecast,
+.dashboard section.dashboard-progress,
+.recent-unlocks > h3,
+.see-more > a,
+.dashboard-sub-section h3 {
+  background-color: var(--ED-surface-2);
+}
+
+.extra-study img,
+.review-forecast__empty-image,
+.none-available div {
+  filter: invert(0.81);
+}
+
+.review-forecast__day-header::before {
+  background-color: var(--ED-surface-2);
+}
+
+.logo,
+.logo:active,
+.logo:focus {
+  filter: invert(1) saturate(0) brightness(1.6);
+}
+
+#query {
+  background-color: var(--ED-surface-1);
+}
+
+.progress-bar {
+  background-color: var(--ED-surface-3);
+}
+
+.progress-bar .progress-bar__progress {
+  background-color: var(--ED-progress-clr);
+  background-image: none;
+}
+
+.bg-gray-500 {
+  background-color: var(--ED-brand);
+}
+
+.sitemap__pages--radical > .sitemap__page--subject,
+.sitemap__section-header--radicals:hover,
+.sitemap__section-header--radicals[data-expanded="true"],
+.sitemap__section-header--radicals:active,
+.sitemap__section-header--radicals:focus,
+.sitemap__section--open .sitemap__section-header--radicals {
+  border-color: var(--ED-radical-clr);
+}
+
+.sitemap__pages--radical li > a:hover,
+.sitemap__expandable-chunk--radicals::before {
+  background-color: var(--ED-radical-clr);
+}
+
+.sitemap__pages--kanji > .sitemap__page--subject,
+.sitemap__section-header--kanji:hover,
+.sitemap__section-header--kanji[data-expanded="true"],
+.sitemap__section-header--kanji:active,
+.sitemap__section-header--kanji:focus,
+.sitemap__section--open .sitemap__section-header--kanji {
+  border-color: var(--ED-kanji-clr);
+}
+
+.sitemap__pages--kanji li > a:hover,
+.sitemap__expandable-chunk--kanji::before {
+  background-color: var(--ED-kanji-clr);
+}
+
+.sitemap__pages--vocabulary > .sitemap__page--subject,
+.sitemap__section-header--vocabulary:hover,
+.sitemap__section-header--vocabulary[data-expanded="true"],
+.sitemap__section-header--vocabulary:active,
+.sitemap__section-header--vocabulary:focus,
+.sitemap__section--open .sitemap__section-header--vocabulary {
+  border-color: var(--ED-vocab-clr);
+}
+
+.sitemap__pages--vocabulary li > a:hover,
+.sitemap__expandable-chunk--vocabulary::before {
+  background-color: var(--ED-vocab-clr);
+}
+
+footer {
+  filter: invert(100%);
+}
+
+footer ul {
+  filter: invert(100%);
+}
+footer ul li:last-child {
+  filter: hue-rotate(50deg) grayscale(0.75) brightness(2.2);
+}
+
+.review-forecast__bar,
+.dashboard section.newbie {
+  background-color: var(--ED-brand);
+}
+
+.border-blue-300 {
+  border-color: var(--ED-brand);
+}
+
+.lessons-and-reviews__lessons-button {
+  --ED-button-fg: var(--ED-text-color);
+  --ED-button-bg: var(--ED-lesson-clr);
+  background-color: var(--ED-button-bg);
+  color: var(--ED-button-fg);
+}
+
+.lessons-and-reviews__lessons-button span {
+  /* count badge inverts fg/bg */
+  background-color: var(--ED-button-fg);
+  color: var(--ED-button-bg);
+}
+
+.lessons-and-reviews .lessons-and-reviews__lessons-button--0 {
+  /* No lessons, no color */
+  --ED-button-fg: var(--ED-text-color);
+  --ED-button-bg: var(--ED-surface-4);
+}
+
+.lessons-and-reviews__reviews-button {
+  --ED-button-fg: var(--ED-text-color);
+  --ED-button-bg: var(--ED-review-clr);
+  background-color: var(--ED-button-bg);
+  color: var(--ED-button-fg);
+}
+
+.lessons-and-reviews__reviews-button span {
+  /* count badge inverts fg/bg */
+  background-color: var(--ED-button-fg);
+  color: var(--ED-button-bg);
+}
+
+.lessons-and-reviews .lessons-and-reviews__reviews-button--0 {
+  /* No reviews, no color */
+  --ED-button-fg: var(--ED-text-color);
+  --ED-button-bg: var(--ED-surface-4);
+}
+
+.lessons-and-reviews__lessons-button:hover,
+.lessons-and-reviews__lessons-button:active,
+.lessons-and-reviews__lessons-button:focus,
+.lessons-and-reviews__reviews-button:hover,
+.lessons-and-reviews__reviews-button:active,
+.lessons-and-reviews__reviews-button:focus {
+  color: var(--ED-highlight-text);
+}
+
+.dashboard section.newbie,
+.dashboard section.dashboard-progress,
+.dashboard section.forecast,
+.progress-entry .kanji-icon,
+.progress-entry .radical-icon,
+.progress-entry .vocabulary-icon,
+.dashboard section.dashboard-sub-section div.see-more,
+.small-caps.invert {
+  border: 0px;
+  box-shadow: 0 0px;
+}
+
+/* RRW Can't find this, either (not a newbie tho :-) */
+.dashboard section.newbie hr {
+  border-color: var(--ED-brand);
+}
+
+section.srs-progress ul li:first-child,
+section.srs-progress ul li:nth-child(2),
+section.srs-progress ul li:nth-child(3),
+section.srs-progress ul li:nth-child(4),
+section.srs-progress ul li:nth-child(5),
+.progress-entry .kanji-icon,
+.progress-entry .radical-icon,
+.progress-entry .vocabulary-icon,
+.forum-topics-list a.small-caps {
+  background-image: none;
+}
+
+section.srs-progress,
+section.srs-progress span {
+  color: var(--ED-text-color);
+}
+
+.radical-icon--locked,
+.kanji-icon--locked {
+  background-color: var(--ED-surface-4) !important;
+  filter: brightness(80%);
+}
+
+.kotoba-table-list table a span,
+.kotoba-table-list table a time,
+.kotoba-table-list table td span.pull-right {
+  color: var(--ED-text-color);
+}
+
+.kotoba-table-list tr[class|="radical"],
+.kotoba-table-list tr[class|="kanji"],
+.kotoba-table-list tr[class|="vocabulary"] {
+  background-image: none;
+}
+
+.kotoba-table-list tr[class|="radical"]:nth-child(odd),
+.kotoba-table-list tr[class|="kanji"]:nth-child(odd),
+.kotoba-table-list tr[class|="vocabulary"]:nth-child(odd) {
+  filter: brightness(1.1);
+}
+
+.kotoba-table-list tr[class|="radical"] {
+  background-color: var(--ED-radical-clr);
+}
+
+.kotoba-table-list tr[class|="kanji"] {
+  background-color: var(--ED-kanji-clr);
+}
+
+.kotoba-table-list tr[class|="vocabulary"] {
+  background-color: var(--ED-vocab-clr);
+}
+
+.small-caps.invert,
+.forum-topics-list table tbody tr td {
+  box-shadow: none;
+  background: none;
+}
+
+.forum-topics-list > h3.small-caps {
+  background-color: var(--ED-surface-2);
+  background-image: none;
+  filter: invert(0);
+}
+
+.forum-topics-list table,
+.forum-topics-list table tbody tr {
+  color: var(--ED-text-color);
+  background-color: var(--ED-surface-3);
+}
+
+.forum-topics-list table tbody tr:hover {
+  background-color: var(--ED-surface-4);
+}
+
+.heading-symbol {
+  filter: brightness(0.86);
+}
+
+.small-caps {
+  border-radius: 0px 0px 5px 5px;
+}
+
+/* RRW Used in the community forum section, God only knows where else. Tightnen
+the selector? */
+.text-blue-500:hover,
+.text-blue-500:active,
+.text-blue-500:focus,
+.forum-topics-list a:hover {
+  color: var(--ED-highlight-text);
+  --tw-ring-color: var(--ED-highlight-text);
+}
+
+.navigation-shortcut {
+  background-image: none;
+  border: none;
+}
+
+/* RRW De-emphasize counts if 0 in shortcut navigation to lessons/reviews in top nav  bar */
+.navigation-shortcut[data-count="0"] span,
+.navigation-shortcut[data-count="0"] .navigation-shortcut__count {
+  background-color: var(--ED-surface-3);
+  color: var(--ED-grayed-text);
+}
+
+/* RRW highlight the counts if work to do */
+.navigation-shortcut a span {
+  background-color: var(--ED-review-clr);
+}
+.navigation-shortcut--lessons a span {
+  background-color: var(--ED-lesson-clr);
+}
+
+/* Popover when hovering over appr/guru/master/enl stage counts */
+.popover.srs .popover-content ul li {
+  background-color: var(--ED-extra-clr);
+  background-image: none !important;
+}
+.popover.srs .popover-inner .popover-content ul li:nth-child(1) {
+  background-color: var(--ED-radical-clr);
+}
+.popover.srs .popover-content ul li:nth-child(2) {
+  background-color: var(--ED-kanji-clr) !important;
+}
+.popover.srs .popover-content ul li:nth-child(3) {
+  background-color: var(--ED-vocab-clr) !important;
+  --ED-text-color: var(--ED-text-light) !important;
+}
+
+.progress-entry .radical-icon {
+  background-color: var(--ED-radical-clr);
+}
+
+.progress-entry .kanji-icon,
+.popover.srs .popover-content ul li:nth-child(2) {
+  background-color: var(--ED-kanji-clr);
+  background-image: none;
+  border: none;
+}
+
+.progress-entry .vocabulary-icon,
+.popover.srs .popover-content ul li:last-child {
+  background-color: var(--ED-vocab-clr);
+  background-image: none;
+  border: none;
+}
+
+section.srs-progress ul li:nth-child(1) {
+  background-color: var(--ED-apprentice-clr);
+}
+
+section.srs-progress ul li:nth-child(2) {
+  background-color: var(--ED-guru-clr);
+}
+
+section.srs-progress ul li:nth-child(3) {
+  background-color: var(--ED-master-clr);
+}
+
+section.srs-progress ul li:nth-child(4) {
+  background-color: var(--ED-enlightened-clr);
+}
+
+section.srs-progress ul li:last-child {
+  background-color: var(--ED-burned-clr);
+}
+
+/* Guru progress indicators under indiviual items */
+.bg-green {
+  background-color: var(--ED-extra-clr);
+}
+
+/*************************************************************************************************/
+/* Review & lesson summary pages
+/*************************************************************************************************/
+
+/* Sticky header */
+#reviews-summary .pure-g-r:first-child,
+#lessons-summary .pure-g-r:first-child {
+  padding: 0 0 10px;
+  position: sticky;
+  top: 0;
+  z-index: 999;
+}
+
+#reviews-summary header,
+#lessons-summary header {
+  background-color: var(--ED-surface-2);
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--ED-surface-4);
+  margin-bottom: 3rem;
+}
+
+#reviews-summary header nav,
+#lessons-summary header nav {
+  position: relative;
+  border: none;
+  margin: 0;
+  padding: 0 20px 0;
+}
+
+#reviews-summary header h1,
+#lessons-summary header h1 {
+  padding: 0 0 0 20px;
+}
+
+#reviews-summary header nav #back-dashboard,
+#lessons-summary header nav #back-dashboard {
+  background-color: var(--ED-brand);
+  box-shadow: none;
+}
+
+#reviews-summary header nav #back-dashboard:hover,
+#lessons-summary header nav #back-dashboard:hover {
+  background-color: var(--ED-brand);
+  filter: brightness(0.8);
+}
+
+#reviews-summary header nav #start-session a.disabled,
+#lessons-summary header nav #start-session a.disabled {
+  background-color: var(--ED-surface-2);
+}
+
+#reviews-summary header nav #start-session a,
+#lessons-summary header nav #start-session a {
+  background-color: var(--ED-brand);
+}
+
+#reviews-summary header nav #start-session a:hover,
+#lessons-summary header nav #start-session a:hover {
+  background-color: var(--ED-brand);
+  filter: brightness(0.8);
+}
+
+#reviews-summary header nav #start-session a:hover.disabled,
+#lessons-summary header nav #start-session a:hover.disabled {
+  background-color: var(--ED-surface-2);
+}
+
+/* RRW Why just apprentice and guru? This smells wrong. */
+#reviews-summary #incorrect .apprentice > ul > li.radicals,
+#reviews-summary #correct .apprentice > ul > li.radicals,
+#reviews-summary #correct .guru > ul > li.radicals {
+  background-color: var(--ED-radical-clr);
+}
+
+/* RRW answered incorrectly headers */
+#reviews-summary #incorrect h2,
+#lessons-summary #radicals h2 {
+  background-color: var(--ED-incorrect);
+}
+
+/* RRW missing radicals and vocabulary? Revisit this */
+#lessons-summary #kanji h2 {
+  background-color: var(--ED-kanji-clr);
+}
+
+/* RRW answered correctly headers */
+#reviews-summary #correct h2,
+#lessons-summary #vocabulary h2 {
+  background-color: var(--ED-correct);
+}
+
+#reviews-summary #review-stats [id*="review-stats-"],
+#reviews-summary #incorrect,
+#reviews-summary #correct,
+#reviews-summary #correct .apprentice h3 span,
+#reviews-summary #incorrect .apprentice h3 span,
+#reviews-summary #correct .apprentice h3 strong,
+#reviews-summary #incorrect .apprentice h3 strong,
+#reviews-summary #correct .guru h3 strong,
+#reviews-summary #incorrect .guru h3 strong,
+#reviews-summary #correct .guru h3 span,
+#reviews-summary #incorrect .guru h3 span,
+#reviews-summary #correct .master h3 strong,
+#reviews-summary #incorrect .master h3 strong,
+#reviews-summary #correct .master h3 span,
+#reviews-summary #incorrect .master h3 span,
+#reviews-summary #correct .enlightened h3 strong,
+#reviews-summary #incorrect .enlightened h3 strong,
+#reviews-summary #correct .enlightened h3 span,
+#reviews-summary #incorrect .enlightened h3 span,
+#reviews-summary #correct .burned h3 strong,
+#reviews-summary #incorrect .burned h3 strong,
+#reviews-summary #correct .burned h3 span,
+#reviews-summary #incorrect .burned h3 span {
+  background-color: var(--ED-surface-2);
+}
+
+#reviews-summary #review-stats [id*="review-stats-"],
+#reviews-summary #incorrect,
+#reviews-summary #correct,
+#reviews-summary #correct .apprentice > ul > li,
+#reviews-summary #incorrect .apprentice > ul > li,
+#reviews-summary #correct .apprentice h3 span,
+#reviews-summary #incorrect .apprentice h3 span,
+#reviews-summary #correct .guru > ul > li,
+#reviews-summary #incorrect .guru > ul > li,
+#reviews-summary #correct .guru h3 span,
+#reviews-summary #incorrect .guru h3 span,
+#reviews-summary #correct .master > ul > li,
+#reviews-summary #incorrect .master > ul > li,
+#reviews-summary #correct .master h3 span,
+#reviews-summary #incorrect .master h3 span,
+#reviews-summary #correct .enlightened > ul > li,
+#reviews-summary #incorrect .enlightened > ul > li,
+#reviews-summary #correct .enlightened h3 span,
+#reviews-summary #incorrect .enlightened h3 span,
+#reviews-summary #correct .burned > ul > li,
+#reviews-summary #incorrect .burned > ul > li,
+#reviews-summary #correct .burned h3 span,
+#reviews-summary #incorrect .burned h3 span,
+#reviews-summary footer #last-session-date,
+#reviews-summary footer #copyright,
+#lessons-summary #radicals,
+#lessons-summary #kanji,
+#lessons-summary #vocabulary,
+#lessons-summary footer #last-session-date,
+#lessons-summary #kanji > div > ul > li.kanji,
+#lessons-summary #radicals > div > ul > li.radicals,
+#lessons-summary #vocabulary > div > ul > li.vocabulary {
+  box-shadow: none;
+  color: var(--ED-text-color);
+  text-shadow: none;
+}
+
+/* prettier-ignore */
+#reviews-summary #review-stats [class*="pure-u-"]:first-child [id*="review-stats-"] {
+  background-color: var(--ED-light-surface-5); /* light background */
+  --ED-text-color: var(--ED-text-dark);
+  color: var(--ED-text-color);
+}
+
+/* prettier-ignore */
+#reviews-summary #review-stats [class*="pure-u-"]:first-child [id*="review-stats-"]::after {
+border-color: transparent transparent transparent var(--ED-light-surface-5);
+}
+
+#reviews-summary footer #last-session-date,
+#reviews-summary footer #copyright,
+#lessons-summary footer #copyright,
+#lessons-summary footer #last-session-date {
+  filter: invert(1);
+  font-size: 16px;
+}
+
+#lessons-summary #radicals > div > ul > li.radicals,
+#reviews-summary #correct .apprentice > ul > li.radical,
+#reviews-summary #incorrect .apprentice > ul > li.radical,
+#reviews-summary #correct .guru > ul > li.radical,
+#reviews-summary #incorrect .guru > ul > li.radical,
+#reviews-summary #correct .master > ul > li.radical,
+#reviews-summary #incorrect .master > ul > li.radical,
+#reviews-summary #correct .enlightened > ul > li.radical,
+#reviews-summary #incorrect .enlightened > ul > li.radical,
+#reviews-summary #correct .burned > ul > li.radical,
+#reviews-summary #incorrect .burned > ul > li.radical,
+.search-results li[class^="radical-"] a {
+  background-color: var(--ED-radical-clr);
+  background-image: none;
+}
+
+#lessons-summary #kanji > div > ul > li.kanji,
+#reviews-summary #correct .apprentice > ul > li.kanji,
+#reviews-summary #incorrect .apprentice > ul > li.kanji,
+#reviews-summary #correct .guru > ul > li.kanji,
+#reviews-summary #incorrect .guru > ul > li.kanji,
+#reviews-summary #correct .master > ul > li.kanji,
+#reviews-summary #incorrect .master > ul > li.kanji,
+#reviews-summary #correct .enlightened > ul > li.kanji,
+#reviews-summary #incorrect .enlightened > ul > li.kanji,
+#reviews-summary #correct .burned > ul > li.kanji,
+#reviews-summary #incorrect .burned > ul > li.kanji,
+.search-results li[class^="kanji-"] a {
+  background-color: var(--ED-kanji-clr);
+  background-image: none;
+}
+
+#lessons-summary #vocabulary > div > ul > li.vocabulary,
+#reviews-summary #correct .apprentice > ul > li.vocabulary,
+#reviews-summary #incorrect .apprentice > ul > li.vocabulary,
+#reviews-summary #correct .guru > ul > li.vocabulary,
+#reviews-summary #incorrect .guru > ul > li.vocabulary,
+#reviews-summary #correct .master > ul > li.vocabulary,
+#reviews-summary #incorrect .master > ul > li.vocabulary,
+#reviews-summary #correct .enlightened > ul > li.vocabulary,
+#reviews-summary #incorrect .enlightened > ul > li.vocabulary,
+#reviews-summary #correct .burned > ul > li.vocabulary,
+#reviews-summary #incorrect .burned > ul > li.vocabulary,
+.search-results li[class^="vocabulary-"] a {
+  background-color: var(--ED-vocab-clr);
+  background-image: none;
+}
+
+#reviews-summary #correct .apprentice > ul > li.kanji,
+#reviews-summary #correct .apprentice > ul > li.radical,
+#reviews-summary #correct .apprentice > ul > li.vocabulary,
+#reviews-summary #incorrect .apprentice > ul > li.radical,
+#reviews-summary #incorrect .apprentice > ul > li.kanji,
+#reviews-summary #incorrect .apprentice > ul > li.vocabulary {
+  text-shadow: none;
+  box-shadow: none;
+  color: var(--ED-text-color);
+}
+
+/* Summary statistics containers on lesson summary pages (might be empty) */
+#lessons-summary #radicals > div,
+#lessons-summary #kanji > div,
+#lessons-summary #vocabulary > div {
+  background-color: var(--ED-surface-2);
+}
+
+/*************************************************************************************************/
+/* Individual review/lesson pages
+/*************************************************************************************************/
+
+/* RRW Freaky! X-ray Wanikani! (loading image) */
+#loading,
+#additional-content-load,
+#loading-screen {
+  filter: grayscale(90%) invert(1) hue-rotate(180deg);
+}
+
+#progress-bar,
+.user-synonyms ul li.user-synonyms-add-btn::before,
+#lesson #supplement-nav,
+.bg-gray-400, /* ugh */
+.user-synonyms ul li.user-synonyms-add-form form button {
+  background-color: var(--ED-surface-2);
+}
+
+#reviews #progress-bar,
+#lesson #progress-bar {
+  height: 10px;
+}
+
+#progress-bar #bar {
+  background-color: var(--ED-progress-clr);
+}
+
+/* Header/prompt with e.g. "Vocabulary **Reading**" */
+#question #question-type.meaning,
+#question #question-type.reading,
+#quiz #question-type.meaning,
+#quiz #question-type.reading {
+  background-color: var(--ED-reading-clr);
+  background-image: none;
+  border-color: var(--ED-reading-clr);
+}
+
+#question #question-type.meaning,
+#quiz #question-type.meaning {
+  background-color: var(--ED-meaning-clr);
+  color: var(--ED-text-color);
+}
+
+#question #question-type h1 {
+  color: var(--ED-text-color);
+}
+
+#item-info #related-items ul {
+  background-color: var(--ED-surface-2);
+}
+
+#question #character.radical,
+.highlight-radical,
+.radical,
+header #main-info.radical,
+#lesson #supplement-info .radical,
+#item-info #related-items ul.radical span {
+  background-color: var(--ED-radical-clr);
+  background-image: none;
+  box-shadow: none;
+  text-shadow: none;
+}
+
+#lessons #stats ul li span.radical {
+  color: var(--ED-radical-clr);
+}
+
+#question #character.kanji,
+.highlight-kanji,
+.kanji,
+header #main-info.kanji,
+#lesson #supplement-info .kanji,
+#item-info #related-items ul.kanji span {
+  background-color: var(--ED-kanji-clr);
+  background-image: none;
+  box-shadow: none;
+  text-shadow: none;
+}
+
+#lessons #stats ul li span.kanji {
+  color: var(--ED-kanji-clr);
+}
+
+#question #character.vocabulary,
+.highlight-vocabulary,
+.vocabulary,
+header #main-info.vocabulary,
+#lesson #supplement-info .vocabulary,
+#item-info #related-items ul.vocabulary span {
+  background-color: var(--ED-vocab-clr);
+  background-image: none;
+  box-shadow: none;
+  text-shadow: none;
+}
+
+#lessons #stats ul li span.vocabulary {
+  color: var(--ED-vocab-clr);
+}
+
+header #main-info.radical #character,
+header #main-info.radical #meaning,
+#lesson #supplement-info .radical,
+header #main-info.kanji #character,
+header #main-info.kanji #meaning,
+#lesson #supplement-info .kanji,
+header #main-info.vocabulary #character,
+header #main-info.vocabulary #meaning,
+#lesson #supplement-info .vocabulary,
+header.quiz #main-info.vocabulary #character,
+header.quiz #main-info.kanji #character,
+header.quiz #main-info.radical #character,
+#lesson #supplement-nav,
+#lesson #supplement-info,
+#lesson #supplement-info #supplement-kan-breakdown ul li div,
+#lesson #supplement-info h2,
+#lesson #supplement-info #supplement-kan-related-vocabulary ul li div,
+.text-gray-900,
+#answer-exception span,
+#item-info #related-items a:visited,
+#item-info #related-items a,
+.user-synonyms ul li.user-synonyms-add-form form input,
+#lesson #supplement-info #supplement-voc-breakdown ul li div,
+#lesson #supplement-info #supplement-rad-related-kanji div {
+  text-shadow: none;
+  box-shadow: none;
+  color: var(--ED-text-color);
+}
+
+#item-info #related-items ul.radical span,
+.reading-highlight {
+  text-shadow: none;
+  box-shadow: none;
+}
+
+/* Upward pointing triangle nav indicator */
+#lesson #supplement-nav ul li.active::before {
+  border-color: transparent transparent var(--ED-surface-2) transparent;
+}
+
+#lesson #supplement-info,
+#quiz {
+  background-color: var(--ED-surface-1);
+  background-image: none;
+}
+
+#quiz .bg-gray-300 {
+  background-color: var(--ED-surface-3);
+}
+
+#lesson #supplement-info {
+  background-color: var(--ED-surface-2);
+  background-image: none;
+}
+
+#answer-form input[type="text"] {
+  box-shadow: none;
+  color: var(--ED-text-color);
+  text-shadow: none;
+  height: 72px;
+  background-color: var(--ED-surface-4);
+}
+
+#answer-form button,
+#lesson #supplement-info blockquote,
+#answer-exception span,
+#item-info #all-info,
+#item-info blockquote,
+[class^="note-"] form fieldset button[type="submit"],
+[class^="note-"] form fieldset button,
+.user-synonyms ul li.user-synonyms-add-form form input {
+  background-color: var(--ED-surface-3);
+  color: var(--ED-text-color);
+}
+
+#answer-exception span::before {
+  border-color: transparent transparent var(--ED-surface-4) transparent;
+}
+
+#additional-content ul li span,
+#additional-content ul li.active i,
+#information {
+  background-color: var(--ED-surface-2);
+  box-shadow: none;
+  color: var(--ED-text-color);
+  line-height: 1;
+}
+
+#additional-content ul li:not(#option-audio) span:hover::before,
+#kana-chart.legacy ul li:not(.empty):hover,
+[class^="note-"] form fieldset {
+  background-color: var(--ED-surface-3);
+  box-shadow: none;
+  color: var(--ED-text-color);
+}
+
+/* RRW Not sure where this is to test this works */
+.highlight-reading,
+.highlight-reading > span,
+.reading-highlight,
+.bg-\[\#f1d6ff\],
+.bg-\[\#f8d8ef\],
+.bg-\[\#d6f1ff\] {
+  background-color: var(--ED-text-color);
+  color: var(--ED-surface-2);
+  text-shadow: none;
+  font-weight: bold;
+  background-image: none;
+}
+
+/* RRW Not sure where this is to test this works */
+.reading-highlight > span {
+  /* --ED-text-color: var(--ED-text-dark); */
+  --ED-text-color: chartreuse;
+}
+
+#information {
+  margin: 0px 10px 10px 10px;
+}
+
+#additional-content ul li.active::before {
+  border-color: transparent transparent var(--ED-surface-2);
+}
+
+#lesson #supplement-nav ul li:hover:not(.active)::before {
+  border-color: transparent transparent var(--ED-surface-2);
+}
+
+#kana-chart.legacy ul li span {
+  filter: invert(1);
+}
+
+#additional-content ul li span:hover {
+  color: var(--ED-surface-1);
+}
+
+.menu-bar,
+.note-meaning,
+#item-info #item-info-col1 section {
+  font-size: 16px;
+}
+
+#answer-form fieldset {
+  position: relative;
+  margin-bottom: 0;
+  padding: 10px;
+  border: 1px solid var(--ED-surface-3);
+}
+
+#answer-form fieldset.correct button,
+#answer-form fieldset.correct input[type="text"],
+#answer-form fieldset.correct input[type="text"]:disabled {
+  background-color: var(--ED-correct) !important;
+}
+
+#answer-form fieldset.incorrect button,
+#answer-form fieldset.incorrect input[type="text"],
+#answer-form fieldset.incorrect input[type="text"]:disabled {
+  background-color: var(--ED-incorrect) !important;
+}
+
+.srs .srs-apprentice {
+  background-color: var(--ED-apprentice-clr);
+  color: var(--ED-text-light);
+}
+
+.srs .srs-guru {
+  background-color: var(--ED-guru-clr);
+  color: var(--ED-text-light);
+}
+
+.srs .srs-master {
+  background-color: var(--ED-master-clr);
+  color: var(--ED-text-light);
+}
+
+.srs .srs-englightened {
+  background-color: var(--ED-enlightened-clr);
+  color: var(--ED-text-light);
+}
+
+/* overlay message */
+
+.screen-overlay--background,
+.dashboard section.system-alert {
+  background-color: var(--ED-alert-clr);
+  background-image: none;
+}
+
+.dashboard section.system-alert {
+  box-shadow: none;
+  border: none;
+  color: var(--ED-text-color);
+}
+
+.dashboard section.system-alert time,
+.dashboard section.system-alert a,
+.dashboard section.system-alert h3 {
+  color: var(--ED-text-color);
+  text-shadow: none;
+  opacity: 1;
+}
+
+.screen-overlay-with-box img,
+.screen-overlay-with-box .btn-set li.dominant a {
+  filter: hue-rotate(160deg);
+}
+.screen-overlay-with-box .btn-set li.dominant a,
+.screen-overlay-with-box .icon-close,
+.screen-overlay-with-box .btn-set li a {
+  filter: hue-rotate(160deg) grayscale(0.4);
+}
+
+section#related-items > .radical {
+  background-color: var(--ED-surface-2);
+}
+
+/* "Last" section when opened */
+
+#information .last-item {
+  background-color: var(--ED-surface-4);
+}
+
+#information .last-item__label,
+#information .last-item__srs-level {
+  color: var(--ED-grayed-text);
+}
+
+#information .last-item__value {
+  color: var(--ED-pure-white);
+}
+
+#information .last-item__characters {
+  color: var(--ED-pure-white);
+}
+
+#information .last-item .last-item__characters--radical {
+  background-color: var(--ED-radical-clr);
+}
+
+#information .last-item .last-item__characters--kanji {
+  background-color: var(--ED-kanji-clr);
+}
+
+#information .last-item .last-item__characters--vocab {
+  background-color: var(--ED-vocab-clr);
+}
+
+/* Item stage movement indicators */
+.srs .srs-up {
+  color: var(--ED-text-color);
+}
+.srs .srs-down {
+  color: var(--ED-grayed-text);
+}
+.srs .srs-apprentice {
+  background-color: var(--ED-apprentice-clr);
+}
+.srs .srs-guru {
+  background-color: var(--ED-guru-clr);
+}
+.srs .srs-master {
+  background-color: var(--ED-master-clr);
+}
+.srs .srs-enlighten {
+  background-color: var(--ED-enlightened-clr);
+}
+.srs .srs-burn {
+  background-color: var(--ED-burned-clr);
+}
+
+/*************************************************************************************************/
+/* Levels page
+/*************************************************************************************************/
+
+.subject-legend,
+.subject-legend__item-badge--recently-unlocked,
+.subject-legend__item-badge--locked,
+.subject-legend__item-badge--all,
+.subject-legend__item-badge--burned,
+.character-grid__header,
+.page-nav__item-link,
+.subject-legend__item-badge--radicals,
+.subject-legend__item-badge--kanji,
+.subject-legend__item-badge--vocabulary {
+  color: var(--ED-pure-white);
+  text-shadow: none;
+  box-shadow: none;
+}
+
+.subject-legend__item-badge--radicals {
+  background-color: var(--ED-radical-clr);
+}
+
+.subject-legend__item-badge--kanji {
+  background-color: var(--ED-kanji-clr);
+}
+
+.subject-legend__item-badge--vocabulary {
+  background-color: var(--ED-vocab-clr);
+}
+
+.subject-legend,
+.character-grid__header,
+.page-nav__item-link {
+  background-color: var(--ED-surface-2);
+}
+
+.page-nav__item-link {
+  border-color: var(--ED-surface-2);
+}
+
+.subject-legend__item-badge--recently-unlocked,
+.component-character__badge,
+.character-item__badge {
+  background-color: var(--ED-brand-alt);
+}
+
+.component-character__badge,
+.character-item__badge {
+  box-shadow: 0px 0px 5px var(--ED-surface-3);
+}
+
+/* Use kanji color for the "New" sample at top of page */
+.subject-legend__item-badge--all {
+  background-color: var(--ED-kanji-clr);
+}
+.subject-legend__item-badge--locked,
+.character-item--locked {
+  filter: brightness(0.5);
+}
+
+.character-item--kanji {
+  background-color: var(--ED-kanji-clr);
+  border-color: var(--ED-gray-3);
+}
+
+.character-item--kanji:not(.character-item--locked) {
+  background-color: var(--ED-kanji-clr);
+  background-image: none;
+}
+
+.character-item--radical {
+  background-color: var(--ED-radical-clr);
+  border-color: var(--ED-gray-3);
+}
+
+.character-item--radical:not(.character-item--locked) {
+  background-color: var(--ED-radical-clr);
+  background-image: none;
+}
+
+.character-item--vocabulary {
+  background-color: var(--ED-vocab-clr);
+  border-color: var(--ED-gray-3);
+}
+
+.character-item--vocabulary:not(.character-item--locked) {
+  background-color: var(--ED-vocab-clr);
+  background-image: none;
+}
+
+.progress-bar__label {
+  box-shadow: none;
+}
+
+.progress-bar__bar {
+  background-color: var(--ED-progress-clr);
+  background-image: none;
+}
+
+.character-grid .progress-bar__label,
+.subject-progress .progress-bar__label {
+  background-color: var(--ED-surface-4);
+}
+
+.progress-bar__label::after,
+.progress-bar__label::before {
+  border-top-color: var(--ED-surface-4);
+}
+
+/*************************************************************************************************/
+/* Individual item page colors
+/*************************************************************************************************/
+
+.page-header__icon--level,
+.page-header__icon--radical,
+.page-header__icon--kanji,
+.page-header__icon--vocabulary,
+.subject-section__title,
+.subject-section__meanings-title,
+.user-synonyms__button,
+.radical-highlight,
+.kanji-highlight,
+.vocabulary-highlight,
+.subject-progress,
+.subject-progress__streak-title,
+.subject-hint__title,
+.subject-section__text,
+.user-note__button,
+.user-note__character-count,
+.user-note,
+#user_reading_note .user-note__input,
+.component-character__meaning,
+.component-character--radical .component-character__characters,
+.subject-readings-with-audio__item,
+.subject-collocations__pattern-collocation--selected,
+.text-black {
+  box-shadow: none;
+  color: var(--ED-text-color);
+  text-shadow: none;
+}
+
+.user-note__button:hover,
+.user-note__button:active,
+.user-note__button:focus {
+  color: var(--ED-highlight-text);
+}
+
+.page-header__icon--radical:hover,
+.page-header__icon--kanji:hover,
+.page-header__icon--vocabulary:hover {
+  box-shadow: none;
+}
+
+.user-synonyms__button,
+.user-synonyms__form-input {
+  background-color: var(--ED-surface-2);
+  border: none;
+}
+
+.user-synonyms__button:hover {
+  color: var(--ED-highlight-text);
+}
+
+.user-synonyms__form-input:focus {
+  outline: 3px solid var(--ED-highlight-text);
+}
+
+.page-header__icon--level,
+.subject-progress__streak-value {
+  background-color: var(--ED-surface-3);
+  background-image: none;
+}
+
+.page-header__icon--radical,
+.radical-highlight,
+.component-character--radical .component-character__characters {
+  background-color: var(--ED-radical-clr);
+  background-image: none;
+}
+
+.page-header__icon--kanji,
+.kanji-highlight {
+  background-color: var(--ED-kanji-clr);
+  background-image: none;
+}
+
+.page-header__icon--vocabulary,
+.vocabulary-highlight {
+  background-color: var(--ED-vocab-clr);
+  background-image: none;
+}
+
+.subject-hint {
+  background-color: var(--ED-surface-3);
+}
+
+.user-note__input,
+.user-note__footer {
+  background-color: var(--ED-surface-2);
+  border: none;
+}
+
+#user_reading_note > .user-note__form {
+  background-color: var(--ED-surface-2);
+}
+
+.fa-solid {
+  color: var(--ED-text-color);
+}
+
+/* where is this? */
+.subject-collocations__patterns::after {
+  box-shadow: none;
+  right: -9px;
+  background-color: chartreuse;
+}
+
+/* "Pattern of Use" separator - found in lessons/reviews of some words/kanji in dropdown boxes*/
+.word-types--with-collocations::after {
+  box-shadow: none;
+  background-color: var(--ED-light-surface-5);
+  left: calc(100% - 1px);
+}
+
+#supplement-voc-context .word-type__button--selected::after {
+  background-color: var(--ED-light-surface-5);
+}
+
+.subject-collocations__pattern-name--selected,
+.context__word-types .bg-gray-300,
+.context__word-types .bg-gray-300 > span {
+  background-color: var(--ED-surface-3);
+  color: var(--ED-text-color);
+}
+
+/* Rex's additions to individual item pages */
+
+.page-header {
+  background-color: var(--ED-surface-2);
+  padding: 10px 20px 0;
+}
+
+.subject-section {
+  background-color: var(--ED-surface-2);
+  padding: 20px;
+}
+
+button.search__button {
+  background-color: var(--ED-light-surface-5);
+  --ED-text-color: var(--ED-text-dark);
+  color: var(--ED-text-color);
+}
+
+span.kanji-highlight,
+span.highlight-kanji,
+span.vocabulary-highlight,
+span.highlight-vocabulary {
+  font-weight: normal;
+  text-shadow: none;
+}
+
+/*************************************************************************************************/
+/* Contact us page
+/*************************************************************************************************/
+
+input[type="text"],
+form .control-group textarea {
+  background-color: var(--ED-surface-2);
+  border: none;
+  box-shadow: none;
+}
+
+input.btn[type="submit"] {
+  --ED-text-color: var(--ED-text-dark);
+}
+
+input[type="text"],
+textarea,
+form label,
+input[type="file"],
+input[type="submit"] {
+  color: var(--ED-text-color);
+  text-shadow: none;
+}
+
+input[type="text"]:focus,
+input[type="text"]:active,
+textarea:focus,
+textarea:active {
+  outline: 3px solid var(--ED-highlight-text);
+}
+
+/*************************************************************************************************/
+/* Profile page
+/*************************************************************************************************/
+
+html#public-profile .public-profile-header::before {
+  background-color: transparent;
+}
+
+html#public-profile .public-profile-header div.avatar {
+  border: 15px solid var(--ED-surface-2);
+}
+
+html#public-profile .public-profile-header div.user-info {
+  background-color: var(--ED-surface-2);
+  background-image: none;
+  box-shadow: none;
+}
+
+/* sheesh. little itty-bitty triangle below profile pic */
+html#public-profile .public-profile-header div.user-info::after {
+  border-bottom-color: var(--ED-surface-2);
+}
+
+html#public-profile .public-profile-header div.user-info h3.small-caps,
+/* prettier-ignore */
+html#public-profile .public-profile-header div.user-info div[class*="span"] ul li,
+html#public-profile div.wall-of-shame h3 span,
+.worst-kanji .progress .bar span,
+.worst-radical .progress .bar span,
+.worst-vocabulary .progress .bar span,
+html#public-profile div.wall-of-shame ul li > span:first-child {
+  color: var(--ED-text-color);
+  text-shadow: none;
+  box-shadow: none;
+}
+
+.kanji-icon,
+.radical-icon,
+.vocabulary-icon {
+  text-shadow: none;
+  box-shadow: none;
+}
+
+html#public-profile div.wall-of-shame {
+  background-color: var(--ED-surface-2);
+}
+
+html#public-profile div.wall-of-shame h3 span {
+  background-color: var(--ED-surface-3);
+}
+
+.radical-icon {
+  background-color: var(--ED-radical-clr);
+}
+
+.kanji-icon {
+  background-color: var(--ED-kanji-clr);
+}
+
+.vocabulary-icon {
+  background-color: var(--ED-vocab-clr);
+}
+
+html#public-profile div.wall-of-shame .progress,
+.kanji-progress .progress,
+.vocabulary-progress .progress {
+  background-color: var(--ED-surface-2);
+}
+
+.progress .bar span {
+  --ED-text-color: var(--ED-text-dark);
+  background-color: var(--ED-light-surface-5);
+  color: var(--ED-text-color);
+  box-shadow: none;
+  text-shadow: none;
+}
+
+.progress .bar span:after {
+  border-top-color: var(--ED-light-surface-5);
+}
+
+.worst-kanji .progress .bar span,
+.worst-radical .progress .bar span,
+.worst-vocabulary .progress .bar span,
+#quiz .bg-gray-300:hover {
+  --ED-text-color: var(--ED-text-dark);
+  background-color: var(--ED-light-surface-5);
+}
+
+.worst-kanji .progress .bar span:after,
+.worst-radical .progress .bar span:after,
+.worst-vocabulary .progress .bar span:after {
+  border-top-color: var(--ED-light-surface-5);
+}
+
+/*************************************************************************************************/
+/* Settings page
+/*************************************************************************************************/
+
+.settings-section,
+.settings-section h2,
+.settings-section .btn,
+.page-list ul > li > a {
+  box-shadow: none;
+  text-shadow: none;
+}
+
+.settings-section,
+.page-list ul > li > a {
+  background-color: var(--ED-surface-2);
+}
+
+.page-list ul {
+  background-color: var(--ED-surface-1);
+}
+
+.page-list ul > li > a {
+  border: none;
+}
+
+.settings-section aside,
+.settings-section .table td,
+#personal-access-tokens-list th,
+.personal-access-token-permissions__namespace-header,
+.personal-access-token-permission__description {
+  color: var(--ED-grayed-text);
+}
+
+.page-list ul > li > a,
+.settings-section h2 {
+  color: var(--ED-text-color);
+}
+
+.account-settings form.form-auto-submit-on-select-change select,
+input[type="password"],
+.settings-section .btn,
+.settings-section select {
+  background-color: var(--ED-light-surface-5);
+  --ED-text-color: var(--ED-text-dark);
+}
+
+.settings-section .btn:hover,
+.settings-section .btn:focus {
+  background-color: var(--ED-yellow);
+}
+
+.settings-section .btn:active {
+  background-color: var(--ED-text-color);
+  color: var(--ED-gray-3);
+}
+
+.indicator--success {
+  background-color: var(--ED-success-clr);
+}
+
+/* Is this necessary? */
+.indicator {
+  border-top: 0.5em solid rgba(255, 255, 255, 0.2);
+  border-right: 0.5em solid rgba(255, 255, 255, 0.2);
+  border-bottom: 0.5em solid rgba(255, 255, 255, 0.2);
+  border-left: 0.5em solid rgba(255, 255, 255, 0.5);
+}
+
+.settings-section input[type="text"] {
+  border: 1px solid var(--ED-text-color);
+  background-color: var(--ED-light-surface-5);
+  --ED-text-color: var(--ED-text-dark);
+}
+
+.settings-section form .control-group textarea {
+  border: 1px solid var(--ED-grayed-text);
+}
+
+/*************************************************************************************************/
+/* Subscription page
+/*************************************************************************************************/
+
+.account-billing .bg-gray-100 {
+  background-color: var(--ED-surface-2);
+}
+
+.account-billing .bg-\[\#00aaff\] {
+  background-color: var(--ED-brand);
+}
+
+.border-blue-300:hover,
+.border-blue-300:active,
+.border-blue-300:focus {
+  border-color: var(--ED-brand);
+}
+
+.account-billing h2 {
+  text-shadow: none;
+  color: var(--ED-text-color);
+}


### PR DESCRIPTION
Changes
=
- Swaped radical and kanji colors
- Changed background of locked radical/kanji on dash
- Dynamicaly linked the lesson button to radical color & the review button to kanji color
- Doubled the height of L/R progress bar
- Changed the default color of all bars to yellow
- Adjusted the inverion on extra study image
- Adjusted the shades of green and yellow
- Changed the A/G/M/E/B colors
- Introduced a color spin based on the default WK colors
---
~~This might be a disappointing update, but after some deliberation, I decided to revert back to the original A/G/M/E/B colors. Some of them might be overloaded due to the overlap with R/K/V, but every alternative I tried proved to be inferior in some form. Lower saturation/brightness variants were unrecognizable from one another when it come to rank up messages in reviews. If I tried turning the knob the other way, the white text became unreadable. Using a gradient run into a similar issue. The uppermost brightness was limited by what the white text allowed for and the remaining spectrum was too short for 4 easily distinguishable shades. The only other option I could think of would be introducing more colors into the theme, which I would like to avoid as much as possible.~~

~~As things stand, I'm ok with the overloaded colors, since there aren't any highlights based on srs level, that could be confused for the R/K/V highlights. The particular colors might be a bit difficult to get used to. Aside from the last 2, they follow the order in which you learn stuff on WK, radical (blue) > kanji (red) > vocab (green). Hopefully, that might be enough for people to adjust to the new progression.~~

On another note. I have added a color spin that drops the whole bunpro color palette in favor of slightly adjusted default WK colors. I like it way more than I expected. Be sure to check it out. For now, I added it to the repository as well, but since it's basically the same css file with minor adjustments, I expect to remove it at some point in the future. Maintaining multiple versions of basically the same file seems redundant.

![obrazek](https://user-images.githubusercontent.com/82216846/213841766-9e9b6195-4baf-4d73-9e56-64708f133e0c.png)
