### PR TITLE
fix forum bg color on dash

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -621,6 +621,15 @@ section.srs-progress ul li:last-child {
   background-color: var(--ED-progress-clr);
 }
 
+.community-banner {
+  background-color: var(--ED-surface-2);
+  border: none;
+}
+
+.community-banner__title {
+  text-shadow: none;
+}
+
 /*************************************************************************************************/
 /* Review & lesson summary pages
 /*************************************************************************************************/


### PR DESCRIPTION
WK apparently nuked the gross forum topics table for a simpler static link.

Added two simple rules to style this.

We _probably_ don't need any of the `.forum-topics-list` stuff any more, but it seems safer to leave it in in case it comes back.