### PR TITLE
use progress-clr for home button on summary pages

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -686,9 +686,12 @@ section.srs-progress ul li:last-child {
   background-color: var(--ED-surface-2);
 }
 
-#reviews-summary header nav #start-session a,
+#reviews-summary header nav #start-session a {
+  background-color: var(--ED-review-clr);
+}
+
 #lessons-summary header nav #start-session a {
-  background-color: var(--ED-brand);
+  background-color: var(--ED-lesson-clr);
 }
 
 #reviews-summary header nav #start-session a:hover,

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -671,7 +671,7 @@ section.srs-progress ul li:last-child {
 
 #reviews-summary header nav #back-dashboard,
 #lessons-summary header nav #back-dashboard {
-  background-color: var(--ED-brand);
+  background-color: var(--ED-progress-clr);
   box-shadow: none;
 }
 


### PR DESCRIPTION
Simple fix. 

This seems worthwhile: the buttons do very different things, but look too similar without the fix. 

Since clicking the home button sends you to the dashboard (where you can view progress), `--ED-progress-clr` seems a reasonable choice for the semantic color.

Appearance with the fix:

![home-after](https://user-images.githubusercontent.com/653208/216690946-7e72337d-54fa-4814-ac77-0702f74b40e6.jpg)

Ooh! This uncovers another "semantics" issue:

The reviews/lessons button currently uses the brand color, which isn't totally unreasonable, but it seems better to use `--ED-reviews-clr` for the reviews summary and `--ED-lessons-clr` on the lessons summary (since that's where they lead to).

