### PR TITLE
Replaced chartreuse with an appropriate color

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -1493,11 +1493,11 @@ section#related-items > .radical {
   color: var(--EDI-text-color);
 }
 
-/* where is this? */
+/* Context menu divider present on some vocab pages */
 .subject-collocations__patterns::after {
   box-shadow: none;
   right: -9px;
-  background-color: chartreuse;
+  background-color: var(--EDI-pure-white);
 }
 
 /* "Pattern of Use" separator - found in lessons/reviews of some words/kanji in dropdown boxes*/

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -1498,6 +1498,7 @@ section#related-items > .radical {
   box-shadow: none;
   right: -9px;
   background-color: var(--EDI-pure-white);
+  filter: brightness(0.85);
 }
 
 /* "Pattern of Use" separator - found in lessons/reviews of some words/kanji in dropdown boxes*/


### PR DESCRIPTION
The style is required since the default page uses a gray to transparent gradient, but as we do not dynamically style the rest of the menu, I opted to use a static white that matches the rest of the default look.
![image](https://user-images.githubusercontent.com/82216846/217168838-e747ec88-7b43-4993-b08f-e51d2c68119a.png)

