### PR TITLE
eliminate --ED-brand-alt

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -60,7 +60,6 @@
 
   /* Theme/branding colors */
   --ED-brand: var(--USER-brand, var(--EDI-red));
-  --ED-brand-alt: var(--USER-brand-alt, var(--EDI-yellow));
 
   /* Indicate reading vs. meaning */
   --ED-meaning-clr: var(--USER-meaning-clr, var(--EDI-yellow));
@@ -1317,7 +1316,7 @@ section#related-items > .radical {
 .subject-legend__item-badge--recently-unlocked,
 .component-character__badge,
 .character-item__badge {
-  background-color: var(--ED-brand-alt);
+  background-color: var(--ED-brand);
 }
 
 .component-character__badge,

--- a/user-overrides/rexs-overrides.css
+++ b/user-overrides/rexs-overrides.css
@@ -163,7 +163,6 @@
   /* Re-used colors */
 
   --USER-brand: var(--USER-enlightened-clr);
-  --USER-brand-alt: var(--USER-brand);
 
   --USER-reading-clr: var(--USER-surface-2);
 


### PR DESCRIPTION
Only used in one rule. It looks like I may have eliminated it in a few spots in a larger change, but forgot to search for other locations where it was used.

This gets rid of it for good.