### PR TITLE
Added !important to stiffle new wk text shadows

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -1541,7 +1541,7 @@ span.highlight-kanji,
 span.vocabulary-highlight,
 span.highlight-vocabulary {
   font-weight: normal;
-  text-shadow: none;
+  text-shadow: none !important;
 }
 
 /*************************************************************************************************/


### PR DESCRIPTION
I opted for the use of `!important` to get rid of the shadows since I do firmly believe they appeared as a consequence of changes at the WK side of things. To account for any future potential changes, this approach should prove more stable.