### PR TITLE
Added customizable img filters

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -270,10 +270,15 @@ table:has(.none-available) + div.see-more {
   background-color: var(--ED-surface-2);
 }
 
-.extra-study img,
+.extra-study img {
+  filter: var(--USER-extra-study-filters, invert(0.81));
+}
+
+/* The elements bellow are only ever visible on fresh accounts */
+/* Since they display on the same surface shade as extra study, they can share a filter var */
 .review-forecast__empty-image,
 .none-available div {
-  filter: invert(0.81);
+  filter: var(--USER-extra-study-filters, invert(0.81));
 }
 
 .review-forecast__day-header::before {
@@ -283,7 +288,7 @@ table:has(.none-available) + div.see-more {
 .logo,
 .logo:active,
 .logo:focus {
-  filter: invert(1) saturate(0) brightness(1.6);
+  filter: var(--USER-logo-filters, invert(1)saturate(0)brightness(1.6));
 }
 
 #query {
@@ -903,7 +908,7 @@ border-color: transparent transparent transparent var(--ED-inverted-surface);
 #loading,
 #additional-content-load,
 #loading-screen {
-  filter: grayscale(90%) invert(1) hue-rotate(180deg);
+  filter: var(--USER-loading-filters, grayscale(90%)invert(1)hue-rotate(180deg));
 }
 
 #progress-bar,

--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -1205,12 +1205,12 @@ header.quiz #main-info.radical #character,
 
 .screen-overlay-with-box img,
 .screen-overlay-with-box .btn-set li.dominant a {
-  filter: hue-rotate(160deg);
+  filter: var(--USER-box-overlay-filters, hue-rotate(160deg));
 }
 .screen-overlay-with-box .btn-set li.dominant a,
 .screen-overlay-with-box .icon-close,
 .screen-overlay-with-box .btn-set li a {
-  filter: hue-rotate(160deg) grayscale(0.4);
+  filter: var(--USER-box-overlay-filters, hue-rotate(160deg)) grayscale(0.4);
 }
 
 section#related-items > .radical {

--- a/user-overrides/All-variables.css
+++ b/user-overrides/All-variables.css
@@ -51,5 +51,6 @@
     /* --USER-logo-filters: invert(1)saturate(0)brightness(1.6) */
     /* --USER-extra-study-filters: invert(0.81) */
     /* --USER-loading-filters: grayscale(90%)invert(1)hue-rotate(180deg) */
+    /* --USER-box-overlay-filters: hue-rotate(160deg) */
   }
 }

--- a/user-overrides/All-variables.css
+++ b/user-overrides/All-variables.css
@@ -47,5 +47,9 @@
     /* --USER-success-clr: #58896f; */
 
     /* --USER-progress-clr: #a97e42; */
+
+    /* --USER-logo-filters: invert(1)saturate(0)brightness(1.6) */
+    /* --USER-extra-study-filters: invert(0.81) */
+    /* --USER-loading-filters: grayscale(90%)invert(1)hue-rotate(180deg) */
   }
 }


### PR DESCRIPTION
So far I decided to implement only 4 variables. The rest of the filters seemed universal enough as to be left static. There are however few things to mention.

The extra study variable is shared between the extra study image itself and some similar more obscure images as seen below.

![image](https://user-images.githubusercontent.com/82216846/218280221-437e629d-f9c3-4ef0-ad15-54aa8a772c2d.png)

The filter of box-overlay images/buttons might be too obscure to warrant inclusion.

![image](https://user-images.githubusercontent.com/82216846/218280321-00efc211-b0f5-4fd3-b9a2-5304b2e3efff.png)
