### PR TITLE
add niai stylesheet

### DIFF
--- a/userscript-styles/WKED-niai.css
+++ b/userscript-styles/WKED-niai.css
@@ -1,0 +1,88 @@
+/* ==UserStyle==
+@name         WKED - Niai Visually Similar Kanji
+@namespace    github.com/openstyles/stylus
+@version      1.0.0
+@license      MIT
+@description  Adds WKED styling to the niai userscript
+@author       Rrwrex
+@homepageURL  https://github.com/Sepitus-exe/WKElementaryDark
+@supportURL   https://github.com/Sepitus-exe/WKElementaryDark/issues
+==/UserStyle== */
+
+/* See https://community.wanikani.com/t/userscript-niai-%E4%BC%BC%E5%90%88%E3%81%84-visually-similar-kanji/23325 */
+
+@-moz-document domain("www.wanikani.com") {
+  niai_section#niai_section#niai_section#niai_section
+    ul.single-character-grid
+    li[data-kanji],
+  #niai_section#niai_section#niai_section#niai_section
+    ul.multi-character-grid
+    li[data-kanji] {
+    color: var(--ED-text);
+    background-color: var(--ED-kanji);
+    background-image: none;
+    border: 1px solid var(--ED-text);
+    filter: none;
+  }
+  #niai_section#niai_section#niai_section#niai_section
+    ul.single-character-grid
+    li[id|="selfkanji"] {
+    background-color: var(--ED-brand) !important;
+    filter: brightness(1.2) !important;
+    background-image: none;
+    border: 1px solid var(--ED-text);
+  }
+  #niai_section#niai_section#niai_section#niai_section
+    ul.single-character-grid
+    li.character-item,
+  #niai_section#niai_section#niai_section#niai_section
+    ul.multi-character-grid
+    li.character-item {
+    color: var(--ED-text);
+    background-color: var(--ED-kanji);
+    background-image: none;
+    filter: none;
+    border: 1px solid var(--ED-text);
+  }
+  #niai_section#niai_section#niai_section#niai_section .btn {
+    color: var(--ED-text-inv);
+    text-shadow: none;
+    background-color: var(--ED-surface-inv);
+    background-image: none;
+    filter: none;
+    border: none;
+    box-shadow: none;
+  }
+  #niai_section#niai_section#niai_section#niai_section .btn span {
+    color: var(--ED-text-inv);
+  }
+  .wk_niai.modal {
+    background-color: var(--ED-surface-3);
+    border: 1px solid var(--ED-text);
+    box-shadow: none;
+  }
+  .wk_niai .modal-header h3,
+  .wk_niai .modal-body label {
+    color: var(--ED-text);
+  }
+  .wk_niai .modal-footer {
+    background-color: var(--ED-surface-4);
+    border-top: 1px solid var(--ED-surface-inv);
+    box-shadow: none;
+  }
+  .wk_niai button.close {
+    background: transparent;
+    color: var(--ED-text);
+  }
+  #niai_section#niai_section#niai_section#niai_section .dropdown-menu {
+    background-color: var(--ED-surface-4);
+    border: 1px solid var(--ED-text);
+    box-shadow: none;
+  }
+  #niai_section#niai_section#niai_section#niai_section .dropdown-menu textarea {
+    background-color: var(--ED-surface-inv);
+    color: var(--ED-text-inv);
+    border: 1px solid var(--ED-text-inv);
+    box-shadow: none;
+  }
+}


### PR DESCRIPTION
Still kinda ugly and horrific looking code, but it's at least functional (and the weird uber-specificity with repeated IDs came from the original).

Before:
![before](https://user-images.githubusercontent.com/653208/220717678-df059bdc-8ce9-4ab4-9abe-665e31c8ec63.jpg)

After (it's subtle, but because the kanji color and the brand color are the same in the default theme, I also made the original kanji in the grid 20% brighter):
![after](https://user-images.githubusercontent.com/653208/220717737-89476929-cc1a-445d-9d7e-134f58fd5738.jpg)

After, with Rex's overrides:
![after-rex](https://user-images.githubusercontent.com/653208/220717870-53b6ef2c-b653-47ed-aef8-b15ceb1a094a.jpg)

Modal before (white on white text):
![modal-before](https://user-images.githubusercontent.com/653208/220717925-cf749992-094a-4cdf-b374-b639989b7255.jpg)

Modal after:
![modal-after](https://user-images.githubusercontent.com/653208/220718639-679fee6a-1012-4b4d-8e7b-6df289508436.jpg)


