### PR TITLE
fixes issue Radicals in info section styled weirdly #123

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -1574,6 +1574,18 @@
   /* Individual item page colors
   /*************************************************************************************************/
 
+  .component-character__characters {
+    width: auto;
+    height: auto;
+    line-height: normal;
+    box-shadow: none;
+    text-shadow: none;
+  }
+
+  #additional-content ul li span.component-character__characters:hover {
+    color: var(--EDI-text-color);
+  }
+
   .page-header__icon--level,
   .page-header__icon--radical,
   .page-header__icon--kanji,


### PR DESCRIPTION
The new code has different markup for the "Radical Combination" info panel.

This PR removes the explicit 44px width/height for the character so it lines up better. It also fixes the text color on hover.