### PR TITLE
fix issue Accordion text shadow #122

### DIFF
--- a/WKElementaryDark.css
+++ b/WKElementaryDark.css
@@ -1456,6 +1456,12 @@
   .character-header--radical .character-header__meaning {
     text-shadow: none;
   }
+
+  .item-info-injector-accordion > button {
+    color: var(--ED-text);
+    text-shadow: none;
+  }
+
   /*************************************************************************************************/
   /* Levels page
   /*************************************************************************************************/


### PR DESCRIPTION
Putting it in the main stylesheet, even though the default accordions don't seem to need it.

I use two scripts that add accordions to reviews: stroke order and niai. Both are affected by this (I'm not sure if the niai script works any more after the WK update).